### PR TITLE
Added typing_extensions to project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
 jsonschema = "==4.16.0"
+typing_extensions = "==4.13.2"
 
 [tool.poetry.group.workflow.dependencies]
 toml = "^0.10.2"

--- a/testguide_report_generator/model/TestCaseFolder.py
+++ b/testguide_report_generator/model/TestCaseFolder.py
@@ -8,7 +8,7 @@
 This module contains the TestCaseFolder class.
 """
 
-from typing_extensions import Self
+from typing import Self
 from testguide_report_generator.model.TestCase import TestCase
 from testguide_report_generator.util.Json2AtxRepr import Json2AtxRepr
 from testguide_report_generator.util.ValidityChecks import check_name_length, gen_error_msg, \

--- a/testguide_report_generator/model/TestCaseFolder.py
+++ b/testguide_report_generator/model/TestCaseFolder.py
@@ -8,7 +8,7 @@
 This module contains the TestCaseFolder class.
 """
 
-from typing import Self
+from typing_extensions import Self
 from testguide_report_generator.model.TestCase import TestCase
 from testguide_report_generator.util.Json2AtxRepr import Json2AtxRepr
 from testguide_report_generator.util.ValidityChecks import check_name_length, gen_error_msg, \


### PR DESCRIPTION
As of https://peps.python.org/pep-0673/ Self can now be used from typing instead of typing_extension  (inspired by https://github.com/microsoft/pylance-release/issues/2034#issuecomment-1207076000)