### PR TITLE
Allow other versions of jsonschema, as long as they are compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
-jsonschema = "==4.16.0"
+jsonschema = "^4.16.0"
 
 [tool.poetry.group.workflow.dependencies]
 toml = "^0.10.2"


### PR DESCRIPTION
Problem:

in lager projects other libs might require slightly other versions of jsonschema. Packamanegers (like poetry) are not able to resolve this kind of conflict of testguide_report-generator insists on exactly version 4.16.0

Proposed solution:

allow SemVer compatible versions of jsonschema as described here: https://python-poetry.org/docs/dependency-specification/#caret-requirements